### PR TITLE
Updated puppet manifest

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -8,6 +8,11 @@ class base {
   exec { 'apt-get update':
     command => '/usr/bin/apt-get update'
   }
+
+  ## Upgrade apt-get ##
+  exec { 'apt-get upgrade':
+    command => '/usr/bin/apt-get -y upgrade'
+  }
 }
 
 class http {
@@ -27,6 +32,7 @@ class http {
 
   service { "apache2":
     ensure => running,
+    notify  => Exec["apt-get update", "apt-get upgrade"],
     require => Package["apache2"],
   }
 }


### PR DESCRIPTION
Updated puppet manifest to run apt-get update and upgrade while running apache service for fetching latest package details to counter mysql package missing errors
